### PR TITLE
Add Sharding Annotations to Flax Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ vNext
 -
 -
 
+0.7.2
+-----
+New features:
+- make `flax.core.copy` `add_or_replace` optional
+- Add `use_fast_variance` option to `GroupNorm` and `BatchNorm` to allow disabling it.
+
+Bug fixes:
+- Use `field_specifiers` instead of `field_descriptors` in `@dataclass_transform`.
+- Fix `nn.Module` typing.
+- [JAX] Replace uses of `jax.experimental.pjit.with_sharding_constraint` with `jax.lax.with_sharding_constraint`.
+
 0.7.1
 -----
 Breaking changes:

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ To cite this repository:
   author = {Jonathan Heek and Anselm Levskaya and Avital Oliver and Marvin Ritter and Bertrand Rondepierre and Andreas Steiner and Marc van {Z}ee},
   title = {{F}lax: A neural network library and ecosystem for {JAX}},
   url = {http://github.com/google/flax},
-  version = {0.7.1},
+  version = {0.7.2},
   year = {2023},
 }
 ```

--- a/docs/api_reference/flax.cursor.rst
+++ b/docs/api_reference/flax.cursor.rst
@@ -1,0 +1,60 @@
+
+flax.cursor package
+=============================
+
+The Cursor API allows for mutability of pytrees. This API provides a more
+ergonomic solution to making partial-updates of deeply nested immutable
+data structures, compared to making many nested ``dataclasses.replace`` calls.
+
+To illustrate, consider the example below::
+
+  from flax.cursor import cursor
+  import dataclasses
+  from typing import Any
+
+  @dataclasses.dataclass
+  class A:
+    x: Any
+
+  a = A(A(A(A(A(A(A(0)))))))
+
+To replace the int 0 using ``dataclasses.replace``, we would have to write many nested calls::
+
+  a2 = dataclasses.replace(
+    a,
+    x=dataclasses.replace(
+      a.x,
+      x=dataclasses.replace(
+        a.x.x,
+        x=dataclasses.replace(
+          a.x.x.x,
+          x=dataclasses.replace(
+            a.x.x.x.x,
+            x=dataclasses.replace(
+              a.x.x.x.x.x,
+              x=dataclasses.replace(a.x.x.x.x.x.x, x=1),
+            ),
+          ),
+        ),
+      ),
+    ),
+  )
+
+The equivalent can be achieved much more simply using the Cursor API::
+
+  a3 = cursor(a).x.x.x.x.x.x.x.set(1)
+  assert a2 == a3
+
+The Cursor object keeps tracks of changes made to it and when ``.build`` is called,
+generates a new object with the accumulated changes. Basic usage involves
+wrapping the object in a Cursor, making changes to the Cursor object and
+generating a new copy of the original object with the accumulated changes.
+
+.. currentmodule:: flax.cursor
+
+.. autofunction:: cursor
+
+.. autoclass:: Cursor
+  :members: build, set, apply_update
+
+

--- a/docs/api_reference/index.rst
+++ b/docs/api_reference/index.rst
@@ -6,6 +6,7 @@ API Reference
 
    flax.config
    flax.core.frozen_dict
+   flax.cursor
    flax.errors
    flax.jax_utils
    flax.linen/index

--- a/docs/flip/2396-rnn.md
+++ b/docs/flip/2396-rnn.md
@@ -1,0 +1,238 @@
+# RNN Flip
+
+- Start Date: 2022-08-18
+- FLIP PR: [#2604](https://github.com/google/flax/pull/2604)
+- FLIP Issue: [#2396](https://github.com/google/flax/issues/2396)
+- Authors: Jasmijn Bastings (@bastings) and Cristian Garcia (@cgarciae)
+
+## Summary
+This FLIP adds support for higher-level recurrent layers (RNN, GRU, LSTM) that can help users process input sequences using the recurrent cells already available in Flax.
+
+## Motivation
+Implementing well known recurrent architectures is tricky and prone to user errors, even a simple LSTM layers involves the manual creation and handling of the carry/memory and correctly setting up `nn.scan`:
+
+```python
+@nn.compact
+def __call__(self, x):
+  LSTM = nn.scan(
+    nn.LSTMCell, variable_broadcast="params", split_rngs={"params": False}
+  )
+  carry = LSTM.initialize_carry(
+    jax.random.PRNGKey(0), batch_dims=x.shape[:1], size=self.hidden_size
+  )
+  carry, x = LSTM()(carry, x)
+  return x
+```
+Slightly more complicated cases involving padding like in the [seq2seq](https://github.com/google/flax/blob/main/examples/seq2seq/models.py) example require even more work but couple potentially be simplified to a couple of lines with the right abstractions. We propose providing users with clean, correct, and efficient abstractions to use recurrent cells. 
+
+## Requirements
+
+* **Masking**: We need to support a batch of sequences that contain padding at the end of each sequence. 
+   * We do not intend to support non-contiguous padding, i.e. padding that is not at the end of a sequence, for performance reasons, except in the case of packing (see below).
+* **Bidirectionality**: The ability to process a sequence in both the forward and reverse directions, respecting padding (i.e., the reverse direction should start with the actual inputs, not with padding values).
+* **Performance**: The proposed classes should be benchmarked to provide the best performance in terms of step time and/or memory use.
+* **Recurrent Dropout**: Support for recurrent dropout in cells (e.g. dropout on the state of the cell).
+
+## Implementation
+### High-level structure
+
+We propose to have these 3 levels of abstraction:
+
+* **Cells (unchanged)**: all RNNCellBase subclasses such as LSTMCell and GRUCell, these implement the stepwise logic. These already exist in Flax today.
+* **Layers (new)**: a class (RNN) that takes a cell and scans over a sequence respecting possible padding values and optionally also allows packed sequences.
+* **Bidirectional (new)**: a single class that takes a forward and a backward RNN instance and correctly processes the input sequence in both directions and merges the results.
+
+### Example of proposed API
+We start with a code example of what you could do with the proposed API, and then we discuss the API in detail below.
+
+```python
+cell = nn.LSTMCell()
+# Encodes a batch of input sequences.
+carry, outputs = nn.RNN(cell, cell_size)(inputs, seq_lengths)
+```
+
+A Bidirectional layer with a LSTM RNNs for the forward and backward directions respectively would look like this:
+
+```python
+forward_rnn = nn.RNN(nn.LSTMCell(), cell_size=32)
+backward_rnn = nn.RNN(nn.LSTMCell(), cell_size=32)
+# Bidirectional combinator.
+bi_rnn = nn.Bidirectional(forward_rnn, backward_rnn)
+# Encodes a batch of input sequences in both directions.
+carry, outputs = bi_rnn(inputs, seq_lengths) 
+```
+
+Next we will discuss `RNN`, `Bidirectional`, and proposed changes to `RNNCellBase`.
+
+### RNNBase
+The `RNNBase` class serves as a base class for the `RNN` class, it specifies
+the API that all RNN layers should implement to be compatible with the `Bidirectional`.
+`RNNBase` contains the `__call__` and `flip_sequences` methods:
+
+```python
+class RNNBase(Protocol):
+  def __call__(
+      self,
+      inputs: jax.Array,
+      *,
+      initial_carry: Optional[Carry] = None,
+      init_key: Optional[random.KeyArray] = None,
+      seq_lengths: Optional[Array] = None,
+      return_carry: Optional[bool] = None,
+      time_major: Optional[bool] = None,
+      reverse: Optional[bool] = None,
+      keep_order: Optional[bool] = None,
+  ) -> Union[Output, Tuple[Carry, Output]]:
+    ...
+```
+Where:
+
+* `inputs`: the input sequence.
+* `initial_carry`: the initial carry, if not provided it will be initialized
+  using the cell's :meth:`RNNCellBase.initialize_carry` method.
+* `init_key`: a PRNG key used to initialize the carry, if not provided
+  ``jax.random.PRNGKey(0)`` will be used. Most cells will ignore this
+  argument.
+* `seq_lengths`: an optional integer array of shape ``(*batch)`` indicating
+  the length of each sequence, elements whose index in the time dimension
+  is greater than the corresponding length will be considered padding and
+  will be ignored.
+* `return_carry`: if ``return_carry=False`` (default) only the output sequence is returned,
+  else it will return a tuple of the final carry and the output sequence.
+* `time_major`: if ``time_major=False`` (default) it will expect inputs with shape
+  ``(*batch, time, *features)``, else it will expect inputs with shape ``(time, *batch, *features)``.
+* `reverse`: if ``reverse=False`` (default) the sequence is
+  processed from left to right and returned in the original order, else it will be processed
+  from right to left, and returned in reverse order. If ``seq_lengths`` is passed,
+  padding will always remain at the end of the sequence.
+* `keep_order`: if ``keep_order=True``, when ``reverse=True``
+  the output will be reversed back to the original order after processing, this is
+  useful to align sequences in bidirectional RNNs. If ``keep_order=False`` (default),
+  the output will remain in the order specified by ``reverse``.
+* `Returns`: if ``return_carry=False`` (default) only the output sequence is returned,
+else it will return a tuple of the final carry and the output sequence.
+
+### RNN
+The `RNN` module inherits from `RNNBase`, it main function is to apply an `RNNCellBase` instance over a batch of input sequences, it can be used with any type of cell (e.g., `GRUCell`, `LSTMCell`, etc). It accepts the following parameters:
+
+```python
+class RNN(RNNBase):
+  cell: RNNCellBase,
+  cell_size: int | Tuple[int, ...]
+  time_axis: int = -2,
+  variable_axes = FrozenDict(),
+  variable_broadcast: CollectionFilter = 'params'
+  variable_carry: CollectionFilter = False
+  split_rngs = FrozenDict({'params': False})
+  # implement RNNBase
+  ...
+```
+
+Attributes like `variable_axes`, `variable_broadcast`, `variable_carry`, and `split_rngs` are directly passed to `nn.scan`, their default values are set such that common cells like `LSTMCell` and `GRUCell` work out of the box.
+
+### Masking
+`seq_lengths` is defined as an integer array of shape `(*batch,)` indicating the length of each sequence.
+
+<details><summary>Discussion</summary>
+
+There are various masking formats found in other frameworks, here are some of the most popular ones:
+
+* **Binary masking**: specifies per-sample and timestep whether that data point should be included or not in the computation, it can be non-contigous (e.g., [1, 1, 0, 1]). This is used by Keras.
+* **Sequence length masking**: specifies per-sample the number of non-padding examples contained in the sequence, any padding contained in the sequence should be stacked at the end. This is used by FlaxFormer.
+* **Segmentation Mask**: specifies row and timestep to which sample the data point belongs to, this format allows more than one sample per row which potentially reduces the total amount of padding needed (e.g. [1, 1, 1, 2, 2, 0, 0]). Pytorch uses this representation (see [pack_padded_sequence](https://pytorch.org/docs/stable/generated/torch.nn.utils.rnn.pack_padded_sequence.html)).
+
+While Sequence packing (see [LM1B example](https://github.com/google/flax/blob/main/examples/lm1b/input_pipeline.py#L90-L92)) is is more powerful, its implementation is more complex and it is not clear whether it is worth the effort. The simplest format is sequence length masking, which is the one we propose to use.
+
+</details>
+
+### Bidirectional
+Bidirectional processing can be achieved via a Module that accepts a `forward_rnn` Module and a `backward_rnn` Module, both of which should be `RNN` instances, in order to process the input sequence in both directions. Here we present some pseudo code of the implementation:
+
+```python
+def __call__(self, inputs, seq_lengths):
+  # Encode in the forward direction.
+  carry_forward, outputs_forward = self.forward_rnn(
+    inputs, seq_lengths=seq_lengths, 
+    return_carry=True, reverse=False,
+  )
+  # Encode in the reverse order.
+  carry_backward, outputs_backward = self.backward_rnn(
+    inputs, seq_lengths=seq_lengths,
+    return_carry=True, reverse=True, # process in reverse order
+    keep_order=True, # but return the sequence in the original order
+  )
+  # Merge both sequences.
+  outputs = jax.tree_map(self.merge_fn, outputs_forward, outputs_backward)
+
+  return (carry_forward, carry_backward), outputs
+```
+
+Here `merge_fn` a function that takes both outputs and fuses them (`concat` by default). As showcased in the beginning of this document, usage would look like this:
+
+```python
+forward_rnn = nn.RNN(nn.LSTMCell(), cell_size=32)
+backward_rnn = nn.RNN(nn.GRUCell(), cell_size=32)
+# Bidirectional combinator.
+bi_rnn = nn.Bidirectional(forward_rnn, backward_rnn)
+# Encodes a batch of input sequences in both directions.
+carry, outputs = bi_rnn(inputs, seq_lengths) 
+```
+
+### Recurrent Dropout
+There are two main uses of dropout in RNNs:
+1. Input dropout: regular dropout applied to the inputs, different for every step.
+4. Recurrent dropout: applies dropout to a recurrent input/output, same for every step.
+
+Flax's `nn.scan` can easily express both types of dropout via `split_rns`, input dropout would split rngs while recurrent dropout would not. [#2540](https://github.com/google/flax/pull/2540) was introduces such that the `rng_name` in `nn.Dropout` can now be defined by the user, this way Cells could define both types of dropout e.g:
+
+```python
+self.dropout = nn.Dropout(...) # input dropout
+self.recurrent_dropout = nn.Dropout(..., rng_collection='recurrent_dropout')
+```
+Based on this, `nn.scan` / `nn.RNN` can now specify `split_rngs` accordingly e.g:
+```
+nn.scan(scan_fn, ..., split_rngs={'dropout': True, 'recurrent_dropout': False})
+```
+
+# Future ideas
+
+<details><summary>show</summary>
+
+### Sequence Packing
+Allow packing multiple sequences to make efficient use of space/memory. This might result in a trade-off where step time is higher (because at each step we need to check whether we are starting a new sequence and reset the carry/initial state), but where less padding is used increasing efficiency overall.
+
+### RNNCell redesign
+
+#### Make initialize_state an instance method
+First altenative is to make `initialize_carry` a instance method. With this change hyperparameters can be passed directly to the cell, it signature would look like this:
+
+```python
+def initialize_carry(self, sample_input) -> Carry:
+  ...
+```
+
+Usage would look like this:
+
+```python
+LSTM = nn.scan(
+  nn.LSTMCell, variable_broadcast='params', 
+  split_rngs={'dropout': True})
+lstm = LSTM(features=32)
+carry = lstm.initialize_carry(x[:, 0])
+carry, y = lstm(carry, x)
+```
+
+#### Remove initialize_carry
+
+An alternative is to remove `initialize_carry` entirely and have the carry state be handled as a carry collection. This would simplify usage quite a bit:
+
+```python
+LSTM = nn.scan(
+  nn.LSTMCell, variable_broadcast='params', 
+  split_rngs={'dropout': True})
+y = LSTM(features=32)(carry, x)
+```
+
+However, this would require `nn.scan` to support initialization of carry collections which is currently not possible. Also, users would have to specify that a collection is mutable e.g. `mutable=['carry']`, even if they are not interested in the output carry state.
+
+</details>

--- a/docs/guides/dropout.rst
+++ b/docs/guides/dropout.rst
@@ -23,7 +23,7 @@ Split the PRNG key
 
 Since dropout is a random operation, it requires a pseudorandom number generator
 (PRNG) state. Flax uses JAX's (splittable) PRNG keys, which have a number of
-desirable properties for neutral networks. To learn more, refer to the
+desirable properties for neural networks. To learn more, refer to the
 `Pseudorandom numbers in JAX tutorial <https://jax.readthedocs.io/en/latest/jax-101/05-random-numbers.html>`__.
 
 **Note:** Recall that JAX has an explicit way of giving you PRNG keys:

--- a/docs/guides/flax_on_pjit.ipynb
+++ b/docs/guides/flax_on_pjit.ipynb
@@ -1046,7 +1046,7 @@
     "  @nn.compact\n",
     "  def __call__(self, x):    \n",
     "    y = nn.Dense(self.depth, \n",
-    "                 kernel_init=nn.with_partitioning(self.dense_init, ('embed', 'hidden')),\n",
+    "                 kernel_init=nn.with_logical_partitioning(self.dense_init, ('embed', 'hidden')),\n",
     "                 use_bias=False,  # or overwrite with `bias_init`\n",
     "                 )(x)\n",
     "\n",
@@ -1056,7 +1056,7 @@
     "\n",
     "    W2 = self.param(\n",
     "        'W2', \n",
-    "        nn.with_partitioning(self.dense_init, ('hidden', 'embed')),\n",
+    "        nn.with_logical_partitioning(self.dense_init, ('hidden', 'embed')),\n",
     "        (self.depth, x.shape[-1]))\n",
     "\n",
     "    z = jnp.dot(y, W2)\n",
@@ -1304,6 +1304,10 @@
  "metadata": {
   "jupytext": {
    "formats": "ipynb,md:myst"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/docs/guides/flax_on_pjit.md
+++ b/docs/guides/flax_on_pjit.md
@@ -450,7 +450,7 @@ class LogicalDotReluDot(nn.Module):
   @nn.compact
   def __call__(self, x):    
     y = nn.Dense(self.depth, 
-                 kernel_init=nn.with_partitioning(self.dense_init, ('embed', 'hidden')),
+                 kernel_init=nn.with_logical_partitioning(self.dense_init, ('embed', 'hidden')),
                  use_bias=False,  # or overwrite with `bias_init`
                  )(x)
 
@@ -460,7 +460,7 @@ class LogicalDotReluDot(nn.Module):
 
     W2 = self.param(
         'W2', 
-        nn.with_partitioning(self.dense_init, ('hidden', 'embed')),
+        nn.with_logical_partitioning(self.dense_init, ('hidden', 'embed')),
         (self.depth, x.shape[-1]))
 
     z = jnp.dot(y, W2)

--- a/docs/guides/haiku_migration_guide.rst
+++ b/docs/guides/haiku_migration_guide.rst
@@ -298,6 +298,10 @@ state. As before, in Flax you construct the Module directly.
 To initialize both the parameters and state you just call the ``init`` method
 as before. However, in Haiku you now get ``state`` as a second return value, and
 in Flax you get a new ``batch_stats`` collection in the ``variables`` dictionary.
+Note that since ``hk.BatchNorm`` only initializes batch statistics when
+``is_training=True``, we must set ``training=True`` when initializing parameters
+of a Haiku model with an ``hk.BatchNorm`` layer. In Flax, we can set
+``training=False`` as usual.
 
 .. codediff::
   :title_left: Haiku
@@ -307,7 +311,7 @@ in Flax you get a new ``batch_stats`` collection in the ``variables`` dictionary
   sample_x = jax.numpy.ones((1, 784))
   params, state = model.init(
     PRNGKey(0),
-    sample_x, training=True # <== inputs
+    sample_x, training=True # <== inputs #!
   )
   ...
 
@@ -315,7 +319,7 @@ in Flax you get a new ``batch_stats`` collection in the ``variables`` dictionary
 
   sample_x = jax.numpy.ones((1, 784))
   variables = model.init(
-    PRNGKey(0),
+    PRNGKey(0), #!
     sample_x, training=False # <== inputs
   )
   params, batch_stats = variables["params"], variables["batch_stats"]

--- a/docs/guides/use_checkpointing.ipynb
+++ b/docs/guides/use_checkpointing.ipynb
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "ArKLnsyGRxGv",
    "metadata": {
     "id": "ArKLnsyGRxGv"
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "SJT9DTxTytjn",
    "metadata": {
     "id": "SJT9DTxTytjn"
@@ -106,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "afd6db30",
    "metadata": {},
    "outputs": [],
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "56dec3f6",
    "metadata": {
     "id": "56dec3f6",
@@ -153,19 +153,16 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: Array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: Array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState())),\n",
-       " 'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       " )>, params={'bias': Array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': Array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState())),\n",
+       " 'config': {'dimensions': array([5, 3])},\n",
        " 'data': [Array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],      dtype=float32)]}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -187,8 +184,8 @@
     "# Perform a simple gradient update similar to the one during a normal training workflow.\n",
     "state = state.apply_gradients(grads=jax.tree_map(jnp.ones_like, state.params))\n",
     "\n",
-    "# Some arbitrary nested pytree with a dictionary, a string, and a NumPy array.\n",
-    "config = {'dimensions': np.array([5, 3]), 'name': 'dense'}\n",
+    "# Some arbitrary nested pytree with a dictionary and a NumPy array.\n",
+    "config = {'dimensions': np.array([5, 3])}\n",
     "\n",
     "# Bundle everything together.\n",
     "ckpt = {'model': state, 'config': config, 'data': [x1]}\n",
@@ -217,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "61b12da2",
    "metadata": {
     "id": "0pp4QtEqW9k7"
@@ -245,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "d3686ea5",
    "metadata": {
     "id": "T6T8V4UBXB1R",
@@ -258,7 +255,7 @@
        "['4', '3']"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -290,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "4cdb35ef",
    "metadata": {
     "id": "4cdb35ef",
@@ -303,7 +300,7 @@
        "'tmp/flax-checkpointing/checkpoint_0'"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -335,7 +332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "a807a9c1",
    "metadata": {
     "id": "WgRJj3wjXIaN",
@@ -345,7 +342,7 @@
     {
      "data": {
       "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       "{'config': {'dimensions': array([5, 3])},\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)],\n",
        " 'model': {'opt_state': [None, None],\n",
@@ -358,7 +355,7 @@
        "  'step': 1}}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -378,14 +375,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "251d7085",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       "{'config': {'dimensions': array([5, 3])},\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)],\n",
        " 'model': {'opt_state': [None, None],\n",
@@ -398,7 +395,7 @@
        "  'step': 1}}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -424,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "150b20a0",
    "metadata": {
     "id": "150b20a0",
@@ -434,7 +431,7 @@
     {
      "data": {
       "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       "{'config': {'dimensions': array([5, 3])},\n",
        " 'data': {'0': array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)},\n",
        " 'model': {'opt_state': {'0': None, '1': None},\n",
@@ -447,7 +444,7 @@
        "  'step': 1}}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -479,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "58f42513",
    "metadata": {
     "id": "58f42513",
@@ -489,7 +486,7 @@
     {
      "data": {
       "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       "{'config': {'dimensions': array([5, 3])},\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)],\n",
        " 'model': TrainState(step=1, apply_fn=<bound method Module.apply of Dense(\n",
@@ -502,17 +499,14 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState()))}"
+       " )>, params={'bias': array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState()))}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -523,7 +517,7 @@
     "    params=jax.tree_map(np.zeros_like, variables['params']),  # values of the tree leaf doesn't matter\n",
     "    tx=tx,\n",
     ")\n",
-    "empty_config = {'dimensions': np.array([0, 0]), 'name': ''}\n",
+    "empty_config = {'dimensions': np.array([0, 0])}\n",
     "target = {'model': empty_state, 'config': empty_config, 'data': [jnp.zeros_like(x1)]}\n",
     "state_restored = orbax_checkpointer.restore('tmp/orbax/single_save', item=target)\n",
     "state_restored"
@@ -541,14 +535,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "a61e9a66",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       "{'config': {'dimensions': array([5, 3])},\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)],\n",
        " 'model': TrainState(step=1, apply_fn=<bound method Module.apply of Dense(\n",
@@ -561,17 +555,14 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState()))}"
+       " )>, params={'bias': array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState()))}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -582,7 +573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "412af50e",
    "metadata": {},
    "outputs": [
@@ -599,20 +590,16 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState())),\n",
-       " 'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
-       " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
-       "        dtype=float32)]}"
+       " )>, params={'bias': array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState())),\n",
+       " 'config': {'dimensions': array([5, 3])},\n",
+       " 'data': [Array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],      dtype=float32)]}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -650,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "be65d4af",
    "metadata": {
     "id": "be65d4af",
@@ -663,7 +650,7 @@
        "True"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -717,14 +704,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "68828029",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       "{'config': {'dimensions': array([5, 3])},\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)],\n",
        " 'model': TrainState(step=0, apply_fn=<bound method Module.apply of Dense(\n",
@@ -737,17 +724,14 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState()))}"
+       " )>, params={'bias': array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState()))}"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -776,7 +760,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 16,
    "id": "a5d14c9f",
    "metadata": {},
    "outputs": [
@@ -792,8 +776,7 @@
      "data": {
       "text/plain": [
        "{'config': None,\n",
-       " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
-       "        dtype=float32)],\n",
+       " 'data': [Array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],      dtype=float32)],\n",
        " 'model': CustomTrainState(step=1, apply_fn=<bound method Module.apply of Dense(\n",
        "     # attributes\n",
        "     features = 3\n",
@@ -804,17 +787,14 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState()), batch_stats=array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))}"
+       " )>, params={'bias': Array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': Array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState()), batch_stats=array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))}"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -848,7 +828,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 17,
    "id": "29fd1e33",
    "metadata": {
     "id": "29fd1e33",
@@ -868,20 +848,16 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState()), batch_stats=array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])),\n",
+       " )>, params={'bias': Array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': Array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState()), batch_stats=array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])),\n",
        " 'config': None,\n",
-       " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
-       "        dtype=float32)]}"
+       " 'data': [Array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],      dtype=float32)]}"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -913,7 +889,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 18,
    "id": "051e7a16",
    "metadata": {},
    "outputs": [
@@ -930,20 +906,17 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState()), batch_stats=array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0])),\n",
-       " 'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       " )>, params={'bias': array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState()), batch_stats=array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0])),\n",
+       " 'config': {'dimensions': array([5, 3])},\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)]}"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -985,7 +958,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 19,
    "id": "85be68a6",
    "metadata": {
     "id": "85be68a6",
@@ -995,7 +968,7 @@
     {
      "data": {
       "text/plain": [
-       "{'config': {'dimensions': array([5, 3]), 'name': 'dense'},\n",
+       "{'config': {'dimensions': array([5, 3])},\n",
        " 'data': [array([0.59902626, 0.2172144 , 2.4202902 , 0.03266738, 1.2164948 ],\n",
        "        dtype=float32)],\n",
        " 'model': TrainState(step=1, apply_fn=<bound method Module.apply of Dense(\n",
@@ -1008,17 +981,14 @@
        "     kernel_init = init\n",
        "     bias_init = zeros\n",
        "     dot_general = dot_general\n",
-       " )>, params=FrozenDict({\n",
-       "     bias: array([-0.001, -0.001, -0.001], dtype=float32),\n",
-       "     kernel: array([[ 0.26048955, -0.61399287, -0.23458514],\n",
-       "            [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
-       "            [ 0.36260957,  0.18276349, -0.6856061 ],\n",
-       "            [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
-       "            [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32),\n",
-       " }), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x158e7cd30>, update=<function chain.<locals>.update_fn at 0x158eaa670>), opt_state=(EmptyState(), EmptyState()))}"
+       " )>, params={'bias': array([-0.001, -0.001, -0.001], dtype=float32), 'kernel': array([[ 0.26048955, -0.61399287, -0.23458514],\n",
+       "        [ 0.11050402, -0.8765793 ,  0.9800635 ],\n",
+       "        [ 0.36260957,  0.18276349, -0.6856061 ],\n",
+       "        [-0.8519373 , -0.6416717 , -0.4818122 ],\n",
+       "        [-0.6886102 , -0.33987316, -0.05898903]], dtype=float32)}, tx=GradientTransformationExtraArgs(init=<function chain.<locals>.init_fn at 0x1564f1280>, update=<function chain.<locals>.update_fn at 0x1564f1ca0>), opt_state=(EmptyState(), EmptyState()))}"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1055,7 +1025,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 20,
    "id": "af33b138",
    "metadata": {},
    "outputs": [],
@@ -1083,7 +1053,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 21,
    "id": "ubdUvyMrhD-1",
    "metadata": {
     "id": "ubdUvyMrhD-1"
@@ -1106,7 +1076,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 22,
    "id": "a669bc05",
    "metadata": {},
    "outputs": [],
@@ -1131,20 +1101,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 23,
    "id": "b8e7daaa",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'model': Array([[0, 1],\n",
-       "        [2, 3],\n",
-       "        [4, 5],\n",
-       "        [6, 7]], dtype=int32)}"
+       "{'model': Array([[ 0,  1],\n",
+       "        [ 2,  3],\n",
+       "        [ 4,  5],\n",
+       "        [ 6,  7],\n",
+       "        [ 8,  9],\n",
+       "        [10, 11],\n",
+       "        [12, 13],\n",
+       "        [14, 15]], dtype=int32)}"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1177,7 +1151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 24,
    "id": "5d10039b",
    "metadata": {
     "id": "5d10039b",
@@ -1190,7 +1164,7 @@
        "'tmp/checkpoint_3'"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1207,7 +1181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 25,
    "id": "a9f9724c",
    "metadata": {
     "id": "a9f9724c",
@@ -1217,13 +1191,17 @@
     {
      "data": {
       "text/plain": [
-       "{'model': Array([[0, 1],\n",
-       "        [2, 3],\n",
-       "        [4, 5],\n",
-       "        [6, 7]], dtype=int32)}"
+       "{'model': Array([[ 0,  1],\n",
+       "        [ 2,  3],\n",
+       "        [ 4,  5],\n",
+       "        [ 6,  7],\n",
+       "        [ 8,  9],\n",
+       "        [10, 11],\n",
+       "        [12, 13],\n",
+       "        [14, 15]], dtype=int32)}"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/docs/guides/use_checkpointing.md
+++ b/docs/guides/use_checkpointing.md
@@ -111,8 +111,8 @@ state = train_state.TrainState.create(
 # Perform a simple gradient update similar to the one during a normal training workflow.
 state = state.apply_gradients(grads=jax.tree_map(jnp.ones_like, state.params))
 
-# Some arbitrary nested pytree with a dictionary, a string, and a NumPy array.
-config = {'dimensions': np.array([5, 3]), 'name': 'dense'}
+# Some arbitrary nested pytree with a dictionary and a NumPy array.
+config = {'dimensions': np.array([5, 3])}
 
 # Bundle everything together.
 ckpt = {'model': state, 'config': config, 'data': [x1]}
@@ -224,7 +224,7 @@ empty_state = train_state.TrainState.create(
     params=jax.tree_map(np.zeros_like, variables['params']),  # values of the tree leaf doesn't matter
     tx=tx,
 )
-empty_config = {'dimensions': np.array([0, 0]), 'name': ''}
+empty_config = {'dimensions': np.array([0, 0])}
 target = {'model': empty_state, 'config': empty_config, 'data': [jnp.zeros_like(x1)]}
 state_restored = orbax_checkpointer.restore('tmp/orbax/single_save', item=target)
 state_restored

--- a/examples/vae/README.md
+++ b/examples/vae/README.md
@@ -5,8 +5,23 @@ This code follows [pytorch/examples/vae](https://github.com/pytorch/examples/blo
 
 ```bash
 pip install -r requirements.txt
-python main.py
+python main.py --workdir=/tmp/mnist --config=configs/default.py
 ```
+
+## Overriding Hyperparameter configurations
+
+This VAE example allows specifying a hyperparameter configuration by the means of
+setting `--config` flag. Configuration flag is defined using
+[config_flags](https://github.com/google/ml_collections/tree/master#config-flags).
+`config_flags` allows overriding configuration fields. This can be done as
+follows:
+
+```shell
+python main.py \
+--workdir=/tmp/mnist --config=configs/default.py \
+--config.learning_rate=0.01 --config.num_epochs=10
+```
+
 
 ## Examples
 

--- a/examples/vae/configs/default.py
+++ b/examples/vae/configs/default.py
@@ -1,0 +1,28 @@
+# Copyright 2023 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Default Hyperparameter configuration."""
+
+import ml_collections
+
+
+def get_config():
+  """Get the default hyperparameter configuration."""
+  config = ml_collections.ConfigDict()
+
+  config.learning_rate = 0.001
+  config.latents = 20
+  config.batch_size = 128
+  config.num_epochs = 30
+  return config

--- a/examples/vae/main.py
+++ b/examples/vae/main.py
@@ -18,16 +18,19 @@ This file is intentionally kept short. The majority for logic is in libraries
 that can be easily tested and imported in Colab.
 """
 
-import jax
-import tensorflow as tf
-import train
-from absl import app, flags, logging
+from absl import app
+from absl import flags
+from absl import logging
 from clu import platform
+import jax
 from ml_collections import config_flags
+import tensorflow as tf
+
+import train
+
 
 FLAGS = flags.FLAGS
 
-flags.DEFINE_string('workdir', None, 'Directory to store model data.')
 config_flags.DEFINE_config_file(
     'config',
     None,
@@ -52,11 +55,8 @@ def main(argv):
       f'process_index: {jax.process_index()}, '
       f'process_count: {jax.process_count()}'
   )
-  platform.work_unit().create_artifact(
-      platform.ArtifactType.DIRECTORY, FLAGS.workdir, 'workdir'
-  )
 
-  train.train_and_evaluate(FLAGS.config, FLAGS.workdir)
+  train.train_and_evaluate(FLAGS.config)
 
 
 if __name__ == '__main__':

--- a/examples/vae/train.py
+++ b/examples/vae/train.py
@@ -27,19 +27,19 @@
 # limitations under the License.
 """Traininga and evaluation logic."""
 
+import input_pipeline
+import jax
+import jax.numpy as jnp
+import ml_collections
+import models
+import optax
+import tensorflow_datasets as tfds
+import utils as vae_utils
 from absl import logging
+from jax import random
 
 from flax import linen as nn
 from flax.training import train_state
-import jax
-from jax import random
-import jax.numpy as jnp
-import optax
-import tensorflow_datasets as tfds
-
-import input_pipeline
-import models
-import utils as vae_utils
 
 
 @jax.vmap
@@ -92,7 +92,8 @@ def eval_f(params, images, z, z_rng, latents):
   return nn.apply(eval_model, models.model(latents))({'params': params})
 
 
-def train_and_evaluate(batch_size, learning_rate, num_epochs, latents):
+def train_and_evaluate(
+    config: ml_collections.ConfigDict, workdir: str):
   """Train and evaulate pipeline."""
   rng = random.PRNGKey(0)
   rng, key = random.split(rng)
@@ -101,32 +102,32 @@ def train_and_evaluate(batch_size, learning_rate, num_epochs, latents):
   ds_builder.download_and_prepare()
 
   logging.info('Initializing dataset.')
-  train_ds = input_pipeline.build_train_set(batch_size, ds_builder)
-  test_ds = input_pipeline.build_test_set(ds_builder)
+  train_ds = input_pipeline.build_train_set(config.batch_size, ds_builder)
+  test_ds = input_pipeline.build_test_set(config.ds_builder)
 
   logging.info('Initializing model.')
-  init_data = jnp.ones((batch_size, 784), jnp.float32)
-  params = models.model(latents).init(key, init_data, rng)['params']
+  init_data = jnp.ones((config.batch_size, 784), jnp.float32)
+  params = models.model(config.latents).init(key, init_data, rng)['params']
 
   state = train_state.TrainState.create(
-      apply_fn=models.model(latents).apply,
+      apply_fn=models.model(config.latents).apply,
       params=params,
-      tx=optax.adam(learning_rate),
+      tx=optax.adam(config.learning_rate),
   )
 
   rng, z_key, eval_rng = random.split(rng, 3)
-  z = random.normal(z_key, (64, latents))
+  z = random.normal(z_key, (64, config.latents))
 
-  steps_per_epoch = ds_builder.info.splits['train'].num_examples // batch_size
+  steps_per_epoch = ds_builder.info.splits['train'].num_examples // config.batch_size
 
-  for epoch in range(num_epochs):
+  for epoch in range(config.num_epochs):
     for _ in range(steps_per_epoch):
       batch = next(train_ds)
       rng, key = random.split(rng)
-      state = train_step(state, batch, key, latents)
+      state = train_step(state, batch, key, config.latents)
 
     metrics, comparison, sample = eval_f(
-        state.params, test_ds, z, eval_rng, latents
+        state.params, test_ds, z, eval_rng, config.latents
     )
     vae_utils.save_image(
         comparison, f'results/reconstruction_{epoch}.png', nrow=8

--- a/examples/vae/train.py
+++ b/examples/vae/train.py
@@ -92,8 +92,7 @@ def eval_f(params, images, z, z_rng, latents):
   return nn.apply(eval_model, models.model(latents))({'params': params})
 
 
-def train_and_evaluate(
-    config: ml_collections.ConfigDict, workdir: str):
+def train_and_evaluate(config: ml_collections.ConfigDict):
   """Train and evaulate pipeline."""
   rng = random.PRNGKey(0)
   rng, key = random.split(rng)
@@ -103,7 +102,7 @@ def train_and_evaluate(
 
   logging.info('Initializing dataset.')
   train_ds = input_pipeline.build_train_set(config.batch_size, ds_builder)
-  test_ds = input_pipeline.build_test_set(config.ds_builder)
+  test_ds = input_pipeline.build_test_set(ds_builder)
 
   logging.info('Initializing model.')
   init_data = jnp.ones((config.batch_size, 784), jnp.float32)
@@ -118,7 +117,9 @@ def train_and_evaluate(
   rng, z_key, eval_rng = random.split(rng, 3)
   z = random.normal(z_key, (64, config.latents))
 
-  steps_per_epoch = ds_builder.info.splits['train'].num_examples // config.batch_size
+  steps_per_epoch = (
+      ds_builder.info.splits['train'].num_examples // config.batch_size
+  )
 
   for epoch in range(config.num_epochs):
     for _ in range(steps_per_epoch):

--- a/flax/core/lift.py
+++ b/flax/core/lift.py
@@ -206,19 +206,22 @@ def pack(
         scope_mutable = intersect_filters(
             intersect_filters(scope.mutable, mutable), mutable_filter
         )
-        new_path = scope.path
+        new_debug_path = scope.debug_path
         if name:
-          if new_path:
-            new_path = new_path[:-1] + (f'{name}({new_path[-1]})',)
+          if new_debug_path:
+            new_debug_path = new_debug_path[:-1] + (
+                f'{name}({new_debug_path[-1]})',
+            )
           else:
-            new_path = (f'{name}()',)
+            new_debug_path = (f'{name}()',)
         inner_scope = Scope(
             variables,
             name=scope.name,
             rngs=rngs,
             mutable=scope_mutable,
             parent=None,
-            path=new_path,
+            path=scope.path,
+            debug_path=new_debug_path,
             flags=scope.flags,
         )
         inner_scope.rng_counters = rng_counters

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -34,6 +34,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
     overload,
 )
 
@@ -892,7 +893,11 @@ class Scope:
         raise errors.ScopeVariableNotFoundError(name, col, self.path_text)
       init_value = init_fn(*init_args)
       self.put_variable(col, name, init_value)
-    return Variable(self, col, name, unbox=unbox)
+    # cast to make static analyzers happy
+    return cast(
+        Union[Variable[T], Variable[meta.AxisMetadata[T]]],
+        Variable(self, col, name, unbox=unbox),
+    )
 
   @overload
   def param(self, name: str, init_fn: Callable[..., T], *init_args) -> T:

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -443,6 +443,7 @@ class Scope:
       mutable: CollectionFilter = False,
       parent: Optional['Scope'] = None,
       path: Iterable[str] = (),
+      debug_path: Iterable[str] = (),
       flags: Optional[Mapping] = None,
   ):
     """Initializes a Scope.
@@ -453,7 +454,9 @@ class Scope:
       name: name of this scope.
       mutable: A CollectionFilter determining which variables are mutable.
       parent: The parent scope.
-      path: The path in the variable tree from the root scope to this scope.
+      path: The path in the variable tree from the root scope to this scope. It
+        exactly matches the module path.
+      debug_path: Similar to path but could contain transformation decorators.
       flags: internal flags.
     """
     rngs = {k: LazyRng.create(v) for k, v in rngs.items()} if rngs else {}
@@ -461,6 +464,7 @@ class Scope:
     self.parent = parent
     self.name = name
     self.path = tuple(path)
+    self.debug_path = tuple(debug_path) or self.path
     self.rngs = rngs
     self.mutable = mutable
     self.flags = freeze({} if flags is None else flags)
@@ -497,8 +501,8 @@ class Scope:
 
   @property
   def path_text(self) -> str:
-    """Returns the path as a human readable string with slashes between parts."""
-    return '/' + '/'.join(self.path)
+    """Returns the debug path as a human readable string."""
+    return '/' + '/'.join(self.debug_path)
 
   @property
   def invalid(self) -> bool:
@@ -559,6 +563,7 @@ class Scope:
         self.mutable,
         self.parent,
         path=self.path,
+        debug_path=self.debug_path,
         flags=self.flags,
     )
     if not rewind_rngs:
@@ -651,6 +656,7 @@ class Scope:
         parent=self,
         mutable=self.mutable,
         path=self.path + (name,),
+        debug_path=self.debug_path + (name,),
         flags=self.flags,
     )
     scope.rng_counters = rng_counters

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -26,6 +26,7 @@ from typing import (
     Dict,
     Generic,
     Iterable,
+    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -33,6 +34,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    overload,
 )
 
 from flax import config as config
@@ -849,9 +851,39 @@ class Scope:
       self.put_variable(col, name, init_value)
     return Variable(self, col, name, unbox=unbox)
 
+  @overload
+  def param(self, name: str, init_fn: Callable[..., T], *init_args) -> T:
+    ...
+
+  @overload
+  def param(
+      self,
+      name: str,
+      init_fn: Callable[..., T],
+      *init_args,
+      unbox: Literal[True],
+  ) -> T:
+    ...
+
+  @overload
+  def param(
+      self,
+      name: str,
+      init_fn: Callable[..., T],
+      *init_args,
+      unbox: Literal[False],
+  ) -> meta.AxisMetadata[T]:
+    ...
+
+  @overload
+  def param(
+      self, name: str, init_fn: Callable[..., T], *init_args, unbox: bool
+  ) -> Union[T, meta.AxisMetadata[T]]:
+    ...
+
   def param(
       self, name: str, init_fn: Callable[..., T], *init_args, unbox: bool = True
-  ) -> T:
+  ) -> Union[T, meta.AxisMetadata[T]]:
     """Creates a parameter if it doesn't exist yet in this scope and returns it.
 
     If the parameter exists already, the existing value is simply returned.

--- a/flax/core/scope.py
+++ b/flax/core/scope.py
@@ -818,6 +818,49 @@ class Scope:
 
     put(variables, name, value)
 
+  @overload
+  def variable(
+      self,
+      col: str,
+      name: str,
+      init_fn: Optional[Callable[..., T]] = None,
+      *init_args,
+  ) -> Variable[T]:
+    ...
+
+  @overload
+  def variable(
+      self,
+      col: str,
+      name: str,
+      init_fn: Optional[Callable[..., T]] = None,
+      *init_args,
+      unbox: Literal[True],
+  ) -> Variable[T]:
+    ...
+
+  @overload
+  def variable(
+      self,
+      col: str,
+      name: str,
+      init_fn: Optional[Callable[..., T]] = None,
+      *init_args,
+      unbox: Literal[False],
+  ) -> Variable[meta.AxisMetadata[T]]:
+    ...
+
+  @overload
+  def variable(
+      self,
+      col: str,
+      name: str,
+      init_fn: Optional[Callable[..., T]] = None,
+      *init_args,
+      unbox: bool = True,
+  ) -> Union[Variable[T], Variable[meta.AxisMetadata[T]]]:
+    ...
+
   def variable(
       self,
       col: str,
@@ -825,7 +868,7 @@ class Scope:
       init_fn: Optional[Callable[..., T]] = None,
       *init_args,
       unbox: bool = True,
-  ) -> Variable[T]:
+  ) -> Union[Variable[T], Variable[meta.AxisMetadata[T]]]:
     """Creates a variable if it doesn't exist yet in this scope and returns it.
 
     Args:

--- a/flax/cursor.py
+++ b/flax/cursor.py
@@ -1,0 +1,392 @@
+import enum
+from typing import Any, Callable, Dict, Generator, Generic, Mapping, Optional, Protocol, Tuple, TypeVar, Union, runtime_checkable
+from flax.core import FrozenDict
+import dataclasses
+
+
+A = TypeVar('A')
+Key = Any
+
+
+@runtime_checkable
+class Indexable(Protocol):
+
+  def __getitem__(self, key) -> Any:
+    ...
+
+
+@dataclasses.dataclass
+class ParentKey(Generic[A]):
+  parent: 'Cursor[A]'
+  key: Any
+
+
+class AccessType(enum.Enum):
+  GETITEM = enum.auto()
+  GETATTR = enum.auto()
+
+
+def is_named_tuple(obj):
+  return (
+      isinstance(obj, tuple)
+      and hasattr(obj, '_fields')
+      and hasattr(obj, '_asdict')
+      and hasattr(obj, '_replace')
+  )
+
+
+def _get_changes(path, obj, update_fn):
+  """Helper function for ``Cursor.apply_update``. Returns a generator of
+  Tuple[Tuple[Union[str, int], Any], ...], where the first element is a
+  tuple key path where the change was applied from the ``update_fn``, and
+  the second element is the newly modified value. If the generator is
+  non-empty, then the tuple key path will always be non-empty as well."""
+  if path:
+    str_path = '/'.join(str(key) for key, _ in path)
+    new_obj = update_fn(str_path, obj)
+    if new_obj is not obj:
+      yield path, new_obj
+      return
+
+  if isinstance(obj, (FrozenDict, dict)):
+    items = obj.items()
+    access_type = AccessType.GETITEM
+  elif is_named_tuple(obj):
+    items = ((name, getattr(obj, name)) for name in obj._fields)  # type: ignore
+    access_type = AccessType.GETATTR
+  elif isinstance(obj, (list, tuple)):
+    items = enumerate(obj)
+    access_type = AccessType.GETITEM
+  elif dataclasses.is_dataclass(obj):
+    items = (
+        (f.name, getattr(obj, f.name))
+        for f in dataclasses.fields(obj)
+        if f.init
+    )
+    access_type = AccessType.GETATTR
+  else:
+    yield from ()  # empty generator
+    return
+
+  for key, value in items:
+    yield from _get_changes(path + ((key, access_type),), value, update_fn)
+
+
+class Cursor(Generic[A]):
+  obj: A
+  parent_key: Optional[ParentKey[A]]
+  changes: Dict[Any, Union[Any, 'Cursor[A]']]
+
+  def __init__(self, obj: A, parent_key: Optional[ParentKey[A]]):
+    # NOTE: we use `vars` here to avoid calling `__setattr__`
+    # vars(self) = self.__dict__
+    vars(self)['obj'] = obj
+    vars(self)['parent_key'] = parent_key
+    vars(self)['changes'] = {}
+
+  @property
+  def root(self) -> 'Cursor[A]':
+    if self.parent_key is None:
+      return self
+    else:
+      return self.parent_key.parent.root  # type: ignore
+
+  def __getitem__(self, key) -> 'Cursor[A]':
+    if key in self.changes:
+      return self.changes[key]
+
+    if not isinstance(self.obj, Indexable):
+      raise TypeError(f'Cannot index into {self.obj}')
+
+    if isinstance(self.obj, Mapping) and key not in self.obj:
+      raise KeyError(f'Key {key} not found in {self.obj}')
+
+    if is_named_tuple(self.obj):
+      return getattr(self, self.obj._fields[key])  # type: ignore
+
+    child = Cursor(self.obj[key], ParentKey(self, key))
+    self.changes[key] = child
+    return child
+
+  def __getattr__(self, name) -> 'Cursor[A]':
+    if name in self.changes:
+      return self.changes[name]
+
+    if not hasattr(self.obj, name):
+      raise AttributeError(f'Attribute {name} not found in {self.obj}')
+
+    child = Cursor(getattr(self.obj, name), ParentKey(self, name))
+    self.changes[name] = child
+    return child
+
+  def __setitem__(self, key, value):
+    if is_named_tuple(self.obj):
+      return setattr(self, self.obj._fields[key], value)  # type: ignore
+    self.changes[key] = Cursor(value, ParentKey(self, key))
+
+  def __setattr__(self, name, value):
+    self.changes[name] = Cursor(value, ParentKey(self, name))
+
+  def set(self, value) -> A:
+    """Set a new value for an attribute, property, element or entry
+    in the Cursor object and return a copy of the original object,
+    containing the new set value.
+
+    Example::
+
+      from flax.cursor import cursor
+      from flax.training import train_state
+      import optax
+
+      dict_obj = {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+      modified_dict_obj = cursor(dict_obj)['b'][0].set(10)
+      assert modified_dict_obj == {'a': 1, 'b': (10, 3), 'c': [4, 5]}
+
+      state = train_state.TrainState.create(
+          apply_fn=lambda x: x,
+          params=dict_obj,
+          tx=optax.adam(1e-3),
+      )
+      modified_state = cursor(state).params['b'][1].set(10)
+      assert modified_state.params == {'a': 1, 'b': (2, 10), 'c': [4, 5]}
+
+    Args:
+      value: the value used to set an attribute, property, element or entry in the Cursor object
+    Returns:
+      A copy of the original object with the new set value.
+    """
+    if self.parent_key is None:
+      return value
+    parent, key = self.parent_key.parent, self.parent_key.key  # type: ignore
+    parent.changes[key] = value
+    return parent.root.build()
+
+  def build(self) -> A:
+    """Create and return a copy of the original object with accumulated changes.
+    This method is to be called after making changes to the Cursor object.
+
+    NOTE: The new object is built bottom-up, the changes will be first applied
+    to the leaf nodes, and then its parent, all the way up to the root.
+
+    Example::
+
+      from flax.cursor import cursor
+      from flax.training import train_state
+      import optax
+
+      dict_obj = {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+      c = cursor(dict_obj)
+      c['b'][0] = 10
+      c['a'] = (100, 200)
+      modified_dict_obj = c.build()
+      assert modified_dict_obj == {'a': (100, 200), 'b': (10, 3), 'c': [4, 5]}
+
+      state = train_state.TrainState.create(
+          apply_fn=lambda x: x,
+          params=dict_obj,
+          tx=optax.adam(1e-3),
+      )
+      new_fn = lambda x: x + 1
+      c = cursor(state)
+      c.params['b'][1] = 10
+      c.apply_fn = new_fn
+      modified_state = c.build()
+      assert modified_state.params == {'a': 1, 'b': (2, 10), 'c': [4, 5]}
+      assert modified_state.apply_fn == new_fn
+
+    Returns:
+      A copy of the original object with the accumulated changes.
+    """
+    changes = {
+        key: child.build() if isinstance(child, Cursor) else child
+        for key, child in self.changes.items()
+    }
+    if isinstance(self.obj, FrozenDict):
+      obj = self.obj.copy(changes)  # type: ignore
+    elif isinstance(self.obj, (dict, list)):
+      obj = self.obj.copy()  # type: ignore
+      for key, value in changes.items():
+        obj[key] = value
+    elif is_named_tuple(self.obj):
+      obj = self.obj._replace(**changes)  # type: ignore
+    elif isinstance(self.obj, tuple):
+      obj = list(self.obj)  # type: ignore
+      for key, value in changes.items():
+        obj[key] = value
+      obj = tuple(obj)  # type: ignore
+    elif dataclasses.is_dataclass(self.obj):
+      obj = dataclasses.replace(self.obj, **changes)  # type: ignore
+    else:
+      obj = self.obj  # type: ignore
+
+      # NOTE: There is a way to try to do a general replace for pytrees, but it requires
+      # the key of `changes` to store the type of access (getattr, getitem, etc.)
+      # in order to access those value from the original object and try to replace them
+      # with the new value. For simplicity, this is not implemented for now.
+      # ----------------------
+      # changed_values = tuple(changes.values())
+      # result = flatten_until_found(self.obj, changed_values)
+
+      # if result is None:
+      #   raise ValueError('Cannot find object in parent')
+
+      # leaves, treedef = result
+      # leaves = [leaf if leaf is not self.obj else value for leaf in leaves]
+      # obj = jax.tree_util.tree_unflatten(treedef, leaves)
+
+    return obj  # type: ignore
+
+  def apply_update(
+      self,
+      update_fn: Callable[[str, Any], Any],
+  ) -> 'Cursor[A]':
+    """Traverse the Cursor object and apply conditional changes recursively via an ``update_fn``.
+    The ``update_fn`` has a function signature of ``(str, Any) -> Any``:
+
+    - The input arguments are the current key path (in the form of a string delimited
+      by '/') and value at that current key path
+    - The output is the new value (either modified by the ``update_fn`` or same as the
+      input value if the condition wasn't fulfilled)
+
+    To generate a copy of the original object with the accumulated changes, call the ``.build`` method.
+
+    NOTES:
+
+    - If the ``update_fn`` returns a modified value, this function will not recurse any further
+      down that branch to apply changes. For example, if we intend to replace an attribute that points
+      to a dictionary with an int, we don't need to look for further changes inside the dictionary,
+      since the dictionary will be replaced anyways.
+    - The ``is`` operator is used to determine whether the return value is modified (by comparing it
+      to the input value). Therefore if the ``update_fn`` modifies a mutable container (e.g. lists,
+      dicts, etc.) and returns the same container, ``.apply_update`` will treat the returned value as
+      unmodified as it contains the same ``id``. To avoid this, return a copy of the modified value.
+    - The ``.apply_update`` WILL NOT apply the ``update_fn`` to the value at the top-most level of
+      the pytree (i.e. the root node). The ``update_fn`` will be applied recursively, starting at the
+      root node's children.
+
+    Example::
+
+      import flax.linen as nn
+      from flax.cursor import cursor
+      import jax
+      import jax.numpy as jnp
+
+      class Model(nn.Module):
+        @nn.compact
+        def __call__(self, x):
+          x = nn.Dense(3)(x)
+          x = nn.relu(x)
+          x = nn.Dense(3)(x)
+          x = nn.relu(x)
+          x = nn.Dense(3)(x)
+          x = nn.relu(x)
+          return x
+
+      params = Model().init(jax.random.PRNGKey(0), jnp.empty((1, 2)))['params']
+
+      def update_fn(path, value):
+        '''Multiply all dense kernel params by 2 and add 1.
+        Subtract the Dense_1 bias param by 1.'''
+        if 'kernel' in path:
+          return value * 2 + 1
+        elif 'Dense_1' in path and 'bias' in path:
+          return value - 1
+        return value
+
+      c = cursor(params)
+      new_params = c.apply_update(update_fn).build()
+      for layer in ('Dense_0', 'Dense_1', 'Dense_2'):
+        assert (new_params[layer]['kernel'] == 2 * params[layer]['kernel'] + 1).all()
+        if layer == 'Dense_1':
+          assert (new_params[layer]['bias'] == jnp.array([-1, -1, -1])).all()
+        else:
+          assert (new_params[layer]['bias'] == params[layer]['bias']).all()
+
+      assert jax.tree_util.tree_all(
+            jax.tree_util.tree_map(
+                lambda x, y: (x == y).all(),
+                params,
+                Model().init(jax.random.PRNGKey(0), jnp.empty((1, 2)))[
+                    'params'
+                ],
+            )
+        ) # make sure original params are unchanged
+
+    Args:
+      update_fn: the function that will conditionally apply changes to the Cursor object
+    Returns:
+      The current Cursor object with the updates applied by the ``update_fn``.
+    """
+    for path, value in _get_changes((), self.obj, update_fn):
+      child = self
+      for key, access_type in path[:-1]:
+        if access_type is AccessType.GETITEM:
+          child = child[key]
+        else:  # access_type is AccessType.GETATTR
+          child = getattr(child, key)
+      key, access_type = path[-1]
+      if access_type is AccessType.GETITEM:
+        child[key] = value
+      else:  # access_type is AccessType.GETATTR
+        setattr(child, key, value)
+
+    return self
+
+
+def cursor(obj: A) -> Cursor[A]:
+  """Wrap Cursor over obj and return it.
+  Changes can then be applied to the Cursor object in the following ways:
+
+  - single-line change via the ``.set`` method
+  - multiple changes, and then calling the ``.build`` method
+  - multiple changes conditioned on the tree path and node value, via the ``.apply_update`` method
+
+  ``.set`` example::
+
+    from flax.cursor import cursor
+
+    dict_obj = {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+    modified_dict_obj = cursor(dict_obj)['b'][0].set(10)
+    assert modified_dict_obj == {'a': 1, 'b': (10, 3), 'c': [4, 5]}
+
+  ``.build`` example::
+
+    from flax.cursor import cursor
+
+    dict_obj = {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+    c = cursor(dict_obj)
+    c['b'][0] = 10
+    c['a'] = (100, 200)
+    modified_dict_obj = c.build()
+    assert modified_dict_obj == {'a': (100, 200), 'b': (10, 3), 'c': [4, 5]}
+
+  ``.apply_update`` example::
+
+    from flax.cursor import cursor
+    from flax.training import train_state
+    import optax
+
+    def update_fn(path, value):
+      '''Replace params with empty dictionary.'''
+      if 'params' in path:
+        return {}
+      return value
+
+    state = train_state.TrainState.create(
+        apply_fn=lambda x: x,
+        params={'a': 1, 'b': 2},
+        tx=optax.adam(1e-3),
+    )
+    c = cursor(state)
+    state2 = c.apply_update(update_fn).build()
+    assert state2.params == {}
+    assert state.params == {'a': 1, 'b': 2} # make sure original params are unchanged
+
+  View the docstrings for each method to see more examples of their usage.
+
+  Args:
+    obj: the object you want to wrap the Cursor in
+  Returns:
+    A Cursor object wrapped around obj.
+  """
+  return Cursor(obj, None)

--- a/flax/linen/__init__.py
+++ b/flax/linen/__init__.py
@@ -92,6 +92,7 @@ from .module import (
     enable_named_call as enable_named_call,
     init_with_output as init_with_output,
     init as init,
+    intercept_methods as intercept_methods,
     merge_param as merge_param,
     nowrap as nowrap,
     override_named_call as override_named_call,

--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -242,8 +242,11 @@ class MultiHeadDotProductAttention(Module):
   attention_fn: Callable[..., Array] = dot_product_attention
   decode: bool = False
   normalize_qk: bool = False
+  # Deprecated, will be removed.
   qkv_dot_general: DotGeneralT = lax.dot_general
   out_dot_general: DotGeneralT = lax.dot_general
+  qkv_dot_general_cls: Any = None
+  out_dot_general_cls: Any = None
 
   @compact
   def __call__(
@@ -289,6 +292,7 @@ class MultiHeadDotProductAttention(Module):
         use_bias=self.use_bias,
         precision=self.precision,
         dot_general=self.qkv_dot_general,
+        dot_general_cls=self.qkv_dot_general_cls,
     )
     # project inputs_q to multi-headed q/k/v
     # dimensions are then [batch..., length, n_heads, n_features_per_head]
@@ -393,6 +397,7 @@ class MultiHeadDotProductAttention(Module):
         param_dtype=self.param_dtype,
         precision=self.precision,
         dot_general=self.out_dot_general,
+        dot_general_cls=self.out_dot_general_cls,
         name='out',  # type: ignore[call-arg]
     )(x)
     return out

--- a/flax/linen/attention.py
+++ b/flax/linen/attention.py
@@ -15,7 +15,7 @@
 """Attention core modules for Flax."""
 
 import functools
-from typing import (Any, Callable, Optional, Tuple)
+from typing import (Any, Callable, Optional, Tuple, Union)
 from flax.linen.dtypes import promote_dtype
 
 from flax.linen import initializers
@@ -334,7 +334,11 @@ class MultiHeadDotProductAttention(Module):
           )
         # update key, value caches with our new 1d spatial slices
         cur_index = cache_index.value
-        indices = (0,) * len(batch_dims) + (cur_index, 0, 0)
+        indices: tuple[Union[int, jax.Array], ...] = (0,) * len(batch_dims) + (
+            cur_index,
+            0,
+            0,
+        )
         key = lax.dynamic_update_slice(cached_key.value, key, indices)
         value = lax.dynamic_update_slice(cached_value.value, value, indices)
         cached_key.value = key

--- a/flax/linen/experimental/layers_with_named_axes.py
+++ b/flax/linen/experimental/layers_with_named_axes.py
@@ -72,7 +72,9 @@ class Dense(nn.Module):
       initializers.zeros_init()
   )
   kernel_axes: Tuple[str, ...] = ()
+  # Deprecated. Will be removed.
   dot_general: DotGeneralT = lax.dot_general
+  dot_general_cls: Any = None
 
   @nn.compact
   def __call__(self, inputs: Array) -> Array:
@@ -93,7 +95,12 @@ class Dense(nn.Module):
         axes=self.kernel_axes,
     )
     kernel = jnp.asarray(kernel, self.dtype)
-    y = self.dot_general(
+
+    if self.dot_general_cls is not None:
+      dot_general = self.dot_general_cls()
+    else:
+      dot_general = self.dot_general
+    y = dot_general(
         inputs,
         kernel,
         (((inputs.ndim - 1,), (0,)), ((), ())),

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -873,10 +873,6 @@ def create_descriptor_wrapper(descriptor: Descriptor):
 # -----------------------------------------------------------------------------
 
 
-def module_field(*, kw_only: bool = False, default: Optional[Any] = ...) -> Any:
-  ...
-
-
 # The ModuleBase class is created only to make static analyzers happy
 # mainly pytype and pyright. Some notes:
 # * pyright (correctly) complains that Module itself is not a dataclass, even
@@ -891,12 +887,14 @@ def module_field(*, kw_only: bool = False, default: Optional[Any] = ...) -> Any:
 # * Other attributes are annotated for completeness. Because we are using
 #   the `if typing.TYPE_CHECKING` pattern, these annotations are not present
 #   at runtime so they don't affect the dataclass behavior.
-@dataclass_transform(field_specifiers=(module_field,))  # type: ignore[literal-required]
+@dataclass_transform()
 class ModuleBase:
   if typing.TYPE_CHECKING:
+    name: Optional[str] = None
     scope: Optional[Scope]
     _state: _ModuleInternalState
     _parent_ref: Union['Module', weakref.ReferenceType['Module'], None]
+    parent: Union['Module', _Sentinel, None]
     __dataclass_fields__: Dict[str, dataclasses.Field]
 
 
@@ -936,10 +934,6 @@ class Module(ModuleBase):
   """
 
   if typing.TYPE_CHECKING:
-    name: Optional[str] = module_field(kw_only=True, default=None)
-    parent: Union['Module', _Sentinel, None] = module_field(
-        kw_only=True, default=None
-    )
 
     def __init__(self, *args, **kwargs):
       # this stub makes sure pytype accepts constructor arguments.

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -29,11 +29,9 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Mapping,
-    NamedTuple,
     Optional,
-    Sequence,
-    Set,
     Tuple,
     Type,
     TypeVar,
@@ -53,6 +51,7 @@ from flax import (
 )
 from flax.core import partial_eval
 from flax.core import Scope
+from flax.core import meta
 from flax.core.frozen_dict import FrozenDict
 from flax.core.scope import (  # pylint: disable=g-multiple-import
     CollectionFilter,
@@ -1382,9 +1381,39 @@ class Module(ModuleBase):
     self._state.children[name] = col
     return v
 
+  @overload
+  def param(self, name: str, init_fn: Callable[..., T], *init_args) -> T:
+    ...
+
+  @overload
+  def param(
+      self,
+      name: str,
+      init_fn: Callable[..., T],
+      *init_args,
+      unbox: Literal[True],
+  ) -> T:
+    ...
+
+  @overload
+  def param(
+      self,
+      name: str,
+      init_fn: Callable[..., T],
+      *init_args,
+      unbox: Literal[False],
+  ) -> meta.AxisMetadata[T]:
+    ...
+
+  @overload
+  def param(
+      self, name: str, init_fn: Callable[..., T], *init_args, unbox: bool
+  ) -> Union[T, meta.AxisMetadata[T]]:
+    ...
+
   def param(
       self, name: str, init_fn: Callable[..., T], *init_args, unbox: bool = True
-  ) -> T:
+  ) -> Union[T, meta.AxisMetadata[T]]:
     """Declares and returns a parameter in this Module.
 
     Parameters are read-only variables in the collection named "params". See

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -862,6 +862,8 @@ def create_descriptor_wrapper(descriptor: Descriptor):
         self.wrapped.__set_name__(*args, **kwargs)
 
     def __getattr__(self, name):
+      if 'wrapped' not in vars(self):
+        raise AttributeError()
       return getattr(self.wrapped, name)
 
   return _DescriptorWrapper(descriptor)

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1666,51 +1666,6 @@ class Module(ModuleBase):
     module = self.clone()
     return module, variables
 
-  @overload
-  def apply(
-      self,
-      variables: VariableDict,
-      *args,
-      rngs: Optional[RNGSequences] = None,
-      method: Union[Callable[..., Any], str, None] = None,
-      mutable: Literal[False],
-      capture_intermediates: Union[
-          bool, Callable[['Module', str], bool]
-      ] = False,
-      **kwargs,
-  ) -> Any:
-    ...
-
-  @overload
-  def apply(
-      self,
-      variables: VariableDict,
-      *args,
-      rngs: Optional[RNGSequences] = None,
-      method: Union[Callable[..., Any], str, None] = None,
-      mutable: CollectionFilter,
-      capture_intermediates: Union[
-          bool, Callable[['Module', str], bool]
-      ] = False,
-      **kwargs,
-  ) -> Tuple[Any, Union[FrozenVariableDict, Dict[str, Any]]]:
-    ...
-
-  @overload
-  def apply(
-      self,
-      variables: VariableDict,
-      *args,
-      rngs: Optional[RNGSequences] = None,
-      method: Union[Callable[..., Any], str, None] = None,
-      mutable: CollectionFilter = False,
-      capture_intermediates: Union[
-          bool, Callable[['Module', str], bool]
-      ] = False,
-      **kwargs,
-  ) -> Union[Any, Tuple[Any, Union[FrozenVariableDict, Dict[str, Any]]]]:
-    ...
-
   @traceback_util.api_boundary
   def apply(
       self,

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1623,6 +1623,51 @@ class Module(ModuleBase):
     module = self.clone()
     return module, variables
 
+  @overload
+  def apply(
+      self,
+      variables: VariableDict,
+      *args,
+      rngs: Optional[RNGSequences] = None,
+      method: Union[Callable[..., Any], str, None] = None,
+      mutable: Literal[False],
+      capture_intermediates: Union[
+          bool, Callable[['Module', str], bool]
+      ] = False,
+      **kwargs,
+  ) -> Any:
+    ...
+
+  @overload
+  def apply(
+      self,
+      variables: VariableDict,
+      *args,
+      rngs: Optional[RNGSequences] = None,
+      method: Union[Callable[..., Any], str, None] = None,
+      mutable: CollectionFilter,
+      capture_intermediates: Union[
+          bool, Callable[['Module', str], bool]
+      ] = False,
+      **kwargs,
+  ) -> Tuple[Any, Union[FrozenVariableDict, Dict[str, Any]]]:
+    ...
+
+  @overload
+  def apply(
+      self,
+      variables: VariableDict,
+      *args,
+      rngs: Optional[RNGSequences] = None,
+      method: Union[Callable[..., Any], str, None] = None,
+      mutable: CollectionFilter = False,
+      capture_intermediates: Union[
+          bool, Callable[['Module', str], bool]
+      ] = False,
+      **kwargs,
+  ) -> Union[Any, Tuple[Any, Union[FrozenVariableDict, Dict[str, Any]]]]:
+    ...
+
   @traceback_util.api_boundary
   def apply(
       self,

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -873,6 +873,10 @@ def create_descriptor_wrapper(descriptor: Descriptor):
 # -----------------------------------------------------------------------------
 
 
+def module_field(*, kw_only: bool = False, default: Optional[Any] = ...) -> Any:
+  ...
+
+
 # The ModuleBase class is created only to make static analyzers happy
 # mainly pytype and pyright. Some notes:
 # * pyright (correctly) complains that Module itself is not a dataclass, even
@@ -887,14 +891,12 @@ def create_descriptor_wrapper(descriptor: Descriptor):
 # * Other attributes are annotated for completeness. Because we are using
 #   the `if typing.TYPE_CHECKING` pattern, these annotations are not present
 #   at runtime so they don't affect the dataclass behavior.
-@dataclass_transform()
+@dataclass_transform(field_specifiers=(module_field,))  # type: ignore[literal-required]
 class ModuleBase:
   if typing.TYPE_CHECKING:
-    name: Optional[str] = None
     scope: Optional[Scope]
     _state: _ModuleInternalState
     _parent_ref: Union['Module', weakref.ReferenceType['Module'], None]
-    parent: Union['Module', _Sentinel, None]
     __dataclass_fields__: Dict[str, dataclasses.Field]
 
 
@@ -934,6 +936,10 @@ class Module(ModuleBase):
   """
 
   if typing.TYPE_CHECKING:
+    name: Optional[str] = module_field(kw_only=True, default=None)
+    parent: Union['Module', _Sentinel, None] = module_field(
+        kw_only=True, default=None
+    )
 
     def __init__(self, *args, **kwargs):
       # this stub makes sure pytype accepts constructor arguments.

--- a/flax/linen/module.py
+++ b/flax/linen/module.py
@@ -1330,14 +1330,57 @@ class Module(ModuleBase):
 
     return module
 
+  @overload
   def variable(
       self,
       col: str,
       name: str,
-      init_fn: Optional[Callable[..., Any]] = None,
+      init_fn: Optional[Callable[..., T]] = None,
+      *init_args,
+  ) -> Variable[T]:
+    ...
+
+  @overload
+  def variable(
+      self,
+      col: str,
+      name: str,
+      init_fn: Optional[Callable[..., T]] = None,
+      *init_args,
+      unbox: Literal[True],
+  ) -> Variable[T]:
+    ...
+
+  @overload
+  def variable(
+      self,
+      col: str,
+      name: str,
+      init_fn: Optional[Callable[..., T]] = None,
+      *init_args,
+      unbox: Literal[False],
+  ) -> Variable[meta.AxisMetadata[T]]:
+    ...
+
+  @overload
+  def variable(
+      self,
+      col: str,
+      name: str,
+      init_fn: Optional[Callable[..., T]] = None,
       *init_args,
       unbox: bool = True,
-  ) -> Variable:
+  ) -> Union[Variable[T], Variable[meta.AxisMetadata[T]]]:
+    ...
+
+  def variable(
+      self,
+      col: str,
+      name: str,
+      init_fn: Optional[Callable[..., T]] = None,
+      *init_args,
+      unbox: bool = True,
+  ) -> Union[Variable[T], Variable[meta.AxisMetadata[T]]]:
     """Declares and returns a variable in this Module.
 
     See :mod:`flax.core.variables` for more information. See also :meth:`param`

--- a/flax/linen/normalization.py
+++ b/flax/linen/normalization.py
@@ -17,6 +17,7 @@
 from typing import Any, Callable, Iterable, Optional, Sequence, Tuple, Union
 from flax.linen.dtypes import canonicalize_dtype
 from flax.linen.module import Module, compact, merge_param  # pylint: disable=g-multiple-import
+from flax.linen.partitioning import param_with_axes
 from jax import lax
 from jax.nn import initializers
 import jax.numpy as jnp
@@ -134,6 +135,7 @@ def _normalize(
     use_scale: bool,
     bias_init: Callable[[PRNGKey, Shape, Dtype], Array],
     scale_init: Callable[[PRNGKey, Shape, Dtype], Array],
+    axes: Tuple[str, ...] = None,
 ):
   """Normalizes the input of a normalization layer and optionally applies a learned scale and bias.
 
@@ -153,6 +155,7 @@ def _normalize(
     use_scale: If true, scale the output.
     bias_init: Initialization function for the bias term.
     scale_init: Initialization function for the scaling function.
+    axes: A tuple of axis names over which to shard parameters.
 
   Returns:
     The normalized input.
@@ -171,16 +174,15 @@ def _normalize(
   mul = lax.rsqrt(var + epsilon)
   args = [x]
   if use_scale:
-    scale = mdl.param(
-        'scale', scale_init, reduced_feature_shape, param_dtype
-    ).reshape(feature_shape)
+    scale = param_with_axes('scale', scale_init, reduced_feature_shape,
+                            param_dtype, axes=axes, module=mdl).reshape(feature_shape)
+
     mul *= scale
     args.append(scale)
   y *= mul
   if use_bias:
-    bias = mdl.param(
-        'bias', bias_init, reduced_feature_shape, param_dtype
-    ).reshape(feature_shape)
+    bias = param_with_axes('bias', bias_init, reduced_feature_shape,
+                           param_dtype, axes=axes, module=mdl).reshape(feature_shape)
     y += bias
     args.append(bias)
   dtype = canonicalize_dtype(*args, dtype=dtype)
@@ -241,6 +243,7 @@ class BatchNorm(Module):
       more details.
     use_fast_variance: If true, use a faster, but less numerically stable,
       calculation for the variance.
+    pjit_axis_names: A tuple of axis names.
   """
 
   use_running_average: Optional[bool] = None
@@ -256,6 +259,7 @@ class BatchNorm(Module):
   axis_name: Optional[str] = None
   axis_index_groups: Any = None
   use_fast_variance: bool = True
+  pjit_axis_name: Tuple[str, ...] = None
 
   @compact
   def __call__(self, x, use_running_average: Optional[bool] = None):
@@ -326,6 +330,7 @@ class BatchNorm(Module):
         self.use_scale,
         self.bias_init,
         self.scale_init,
+        self.pjit_axis_name,
     )
 
 
@@ -360,6 +365,7 @@ class LayerNorm(Module):
       more details.
     use_fast_variance: If true, use a faster, but less numerically stable,
       calculation for the variance.
+    pjit_axis_names: A tuple of axis names.
   """
 
   epsilon: float = 1e-6
@@ -374,6 +380,7 @@ class LayerNorm(Module):
   axis_name: Optional[str] = None
   axis_index_groups: Any = None
   use_fast_variance: bool = True
+  pjit_axis_name: Tuple[str, ...] = None
 
   @compact
   def __call__(self, x):
@@ -408,6 +415,7 @@ class LayerNorm(Module):
         self.use_scale,
         self.bias_init,
         self.scale_init,
+        self.pjit_axis_name,
     )
 
 
@@ -449,6 +457,7 @@ class RMSNorm(Module):
       example, `[[0, 1], [2, 3]]` would independently batch-normalize over the
       examples on the first two and last two devices. See `jax.lax.psum` for
       more details.
+    pjit_axis_names: A tuple of axis names.
   """
 
   epsilon: float = 1e-6
@@ -460,6 +469,7 @@ class RMSNorm(Module):
   feature_axes: Axes = -1
   axis_name: Optional[str] = None
   axis_index_groups: Any = None
+  pjit_axis_name: Tuple[str, ...] = None
 
   @compact
   def __call__(self, x):
@@ -494,6 +504,7 @@ class RMSNorm(Module):
         self.use_scale,
         initializers.zeros,
         self.scale_init,
+        self.pjit_axis_name,
     )
 
 
@@ -531,6 +542,7 @@ class GroupNorm(Module):
       more details.
     use_fast_variance: If true, use a faster, but less numerically stable,
       calculation for the variance.
+    pjit_axis_names: A tuple of axis names.
   """
 
   num_groups: Optional[int] = 32
@@ -545,6 +557,7 @@ class GroupNorm(Module):
   axis_name: Optional[str] = None
   axis_index_groups: Any = None
   use_fast_variance: bool = True
+  pjit_axis_name: Tuple[str, ...] = None
 
   @compact
   def __call__(self, x):
@@ -617,4 +630,5 @@ class GroupNorm(Module):
         self.use_scale,
         self.bias_init,
         self.scale_init,
+        self.pjit_axis_name,
     )

--- a/flax/linen/spmd.py
+++ b/flax/linen/spmd.py
@@ -345,7 +345,7 @@ def with_logical_partitioning(
   @functools.wraps(fn)
   def wrapper(*args, **kwargs):
     return LogicallyPartitioned(
-        fn(*args, **kwargs), names, rules=rules, mesh=mesh
-    )
+        fn(*args, **kwargs), names, mesh=mesh, rules=rules
+    )  # pytype: disable=wrong-keyword-args
 
   return wrapper

--- a/flax/serialization.py
+++ b/flax/serialization.py
@@ -105,9 +105,9 @@ def to_state_dict(target) -> Dict[str, Any]:
 
   ty_to_state_dict = _STATE_DICT_REGISTRY[ty][0]
   state_dict = ty_to_state_dict(target)
-  assert isinstance(state_dict, dict), 'A state dict must be a Python dict.'
-  for key in state_dict.keys():
-    assert isinstance(key, str), 'A state dict must only have string keys.'
+  if isinstance(state_dict, dict):
+    for key in state_dict.keys():
+      assert isinstance(key, str), 'A state dict must only have string keys.'
   return state_dict
 
 

--- a/flax/version.py
+++ b/flax/version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 """Current Flax version at head on Github."""
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "orbax-checkpoint",
     "tensorstore",
     "rich>=11.1",
-    "typing_extensions>=4.1.1",
+    "typing_extensions>=4.2",
     "PyYAML>=5.4.1",
 ]
 classifiers = [

--- a/tests/cursor_test.py
+++ b/tests/cursor_test.py
@@ -1,0 +1,332 @@
+# Copyright 2023 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for flax.struct."""
+
+
+from absl.testing import absltest
+import jax
+import jax.numpy as jnp
+import optax
+from typing import Any, Generic, NamedTuple
+
+import flax.linen as nn
+from flax.core import freeze
+from flax.cursor import cursor
+from flax.training import train_state
+
+# Parse absl flags test_srcdir and test_tmpdir.
+jax.config.parse_flags_with_absl()
+
+
+class GenericTuple(NamedTuple):
+  x: Any
+  y: Any = None
+
+
+class CursorTest(absltest.TestCase):
+
+  def test_set_and_build(self):
+    # test regular dict and FrozenDict
+    dict_obj = {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+    for d, freeze_wrap in ((dict_obj, lambda x: x), (freeze(dict_obj), freeze)):
+      # set API
+      self.assertEqual(
+          cursor(d)['b'][0].set(10),
+          freeze_wrap({'a': 1, 'b': (10, 3), 'c': [4, 5]}),
+      )
+      # build API
+      c = cursor(d)
+      c['b'][0] = 20
+      c['a'] = (100, 200)
+      d2 = c.build()
+      self.assertEqual(
+          d2, freeze_wrap({'a': (100, 200), 'b': (20, 3), 'c': [4, 5]})
+      )
+    self.assertEqual(
+        dict_obj, {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+    )  # make sure original object is unchanged
+
+    # test list and tuple
+    list_obj = [0, dict_obj, (1, 2), [3, 4, 5]]
+    for l, tuple_wrap in ((list_obj, lambda x: x), (tuple(list_obj), tuple)):
+      # set API
+      self.assertEqual(
+          cursor(l)[1]['b'][0].set(10),
+          tuple_wrap(
+              [0, {'a': 1, 'b': (10, 3), 'c': [4, 5]}, (1, 2), [3, 4, 5]]
+          ),
+      )
+      # build API
+      c = cursor(l)
+      c[1]['b'][0] = 20
+      c[2] = (100, 200)
+      l2 = c.build()
+      self.assertEqual(
+          l2,
+          tuple_wrap(
+              [0, {'a': 1, 'b': (20, 3), 'c': [4, 5]}, (100, 200), [3, 4, 5]]
+          ),
+      )
+    self.assertEqual(
+        list_obj, [0, {'a': 1, 'b': (2, 3), 'c': [4, 5]}, (1, 2), [3, 4, 5]]
+    )  # make sure original object is unchanged
+
+    # test TrainState
+    state = train_state.TrainState.create(
+        apply_fn=lambda x: x,
+        params=dict_obj,
+        tx=optax.adam(1e-3),
+    )
+    # set API
+    self.assertEqual(
+        cursor(state).params['b'][0].set(10).params,
+        {'a': 1, 'b': (10, 3), 'c': [4, 5]},
+    )
+    # build API
+    new_fn = lambda x: x + 1
+    c = cursor(state)
+    c.apply_fn = new_fn
+    c.params['b'][0] = 20
+    c.params['a'] = (100, 200)
+    state2 = c.build()
+    self.assertEqual(state2.apply_fn, new_fn)
+    self.assertEqual(
+        state2.params, {'a': (100, 200), 'b': (20, 3), 'c': [4, 5]}
+    )
+
+    self.assertEqual(
+        dict_obj, {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+    )  # make sure original object is unchanged
+
+    # test NamedTuple
+    # set API
+    t = GenericTuple(GenericTuple(0))
+    self.assertEqual(cursor(t).x.x.set(1), GenericTuple(GenericTuple(1)))
+
+    # build API
+    c = cursor(t)
+    c.x.x = 2
+    c.x.y = 3
+    c.y = 4
+    t2 = c.build()
+    self.assertEqual(t2, GenericTuple(GenericTuple(2, 3), 4))
+
+    self.assertEqual(
+        t, GenericTuple(GenericTuple(0))
+    )  # make sure original object is unchanged
+
+  def test_apply_update(self):
+    # test list and tuple
+    def update_fn(path, value):
+      """Multiply the first element of all leaf nodes of the pytree by -1."""
+      if path[-1] == '0' and isinstance(value, int):
+        return value * -1
+      return value
+
+    for tuple_wrap in (lambda x: x, tuple):
+      l = tuple_wrap([tuple_wrap([1, 2]), tuple_wrap([3, 4])])
+      c = cursor(l)
+      l2 = c.apply_update(update_fn).build()
+      self.assertEqual(
+          l2, tuple_wrap([tuple_wrap([-1, 2]), tuple_wrap([-3, 4])])
+      )
+      self.assertEqual(
+          l, tuple_wrap([tuple_wrap([1, 2]), tuple_wrap([3, 4])])
+      )  # make sure the original object is unchanged
+
+    # test regular dict and FrozenDict
+    def update_fn(path, value):
+      """Multiply all dense kernel params by 2 and add 1.
+      Subtract the Dense_1 bias param by 1."""
+      if 'kernel' in path:
+        return value * 2 + 1
+      elif 'Dense_1' in path and 'bias' in path:
+        return value - 1
+      return value
+
+    class Model(nn.Module):
+
+      @nn.compact
+      def __call__(self, x):
+        x = nn.Dense(3)(x)
+        x = nn.relu(x)
+        x = nn.Dense(3)(x)
+        x = nn.relu(x)
+        x = nn.Dense(3)(x)
+        x = nn.relu(x)
+        return x
+
+    for freeze_wrap in (lambda x: x, freeze):
+      params = freeze_wrap(
+          Model().init(jax.random.PRNGKey(0), jnp.empty((1, 2)))['params']
+      )
+
+      c = cursor(params)
+      params2 = c.apply_update(update_fn).build()
+      for layer in ('Dense_0', 'Dense_1', 'Dense_2'):
+        self.assertTrue(
+            (params2[layer]['kernel'] == 2 * params[layer]['kernel'] + 1).all()
+        )
+        if layer == 'Dense_1':
+          self.assertTrue(
+              (params2[layer]['bias'] == jnp.array([-1, -1, -1])).all()
+          )
+        else:
+          self.assertTrue(
+              (params2[layer]['bias'] == params[layer]['bias']).all()
+          )
+      self.assertTrue(
+          jax.tree_util.tree_all(
+              jax.tree_util.tree_map(
+                  lambda x, y: (x == y).all(),
+                  params,
+                  freeze_wrap(
+                      Model().init(jax.random.PRNGKey(0), jnp.empty((1, 2)))[
+                          'params'
+                      ]
+                  ),
+              )
+          )
+      )  # make sure original params are unchanged
+
+    # test TrainState
+    def update_fn(path, value):
+      """Replace params with empty dictionary."""
+      if 'params' in path:
+        return {}
+      return value
+
+    state = train_state.TrainState.create(
+        apply_fn=lambda x: x,
+        params={'a': 1, 'b': 2},
+        tx=optax.adam(1e-3),
+    )
+    c = cursor(state)
+    state2 = c.apply_update(update_fn).build()
+    self.assertEqual(state2.params, {})
+    self.assertEqual(
+        state.params, {'a': 1, 'b': 2}
+    )  # make sure original params are unchanged
+
+    # test NamedTuple
+    def update_fn(path, value):
+      """Add 5 to all x-attribute values that are ints"""
+      if path[-1] == 'x' and isinstance(value, int):
+        return value + 5
+      return value
+
+    t = GenericTuple(GenericTuple(0, 1), GenericTuple(2, 3))
+    c = cursor(t)
+    t2 = c.apply_update(update_fn).build()
+    self.assertEqual(t2, GenericTuple(GenericTuple(5, 1), GenericTuple(7, 3)))
+    self.assertEqual(
+        t, GenericTuple(GenericTuple(0, 1), GenericTuple(2, 3))
+    )  # make sure original object is unchanged
+
+  def test_apply_update_root_node_unmodified(self):
+    def update_fn(path, value):
+      if isinstance(value, list):
+        value = value.copy()
+        value.append(-1)
+      return value
+
+    l = [[1, 2], [3, 4], 5]
+    l2 = cursor(l).apply_update(update_fn).build()
+    self.assertEqual(l2, [[1, 2, -1], [3, 4, -1], 5])
+
+  def test_multi_modify(self):
+    d = {'a': 1, 'b': (2, 3), 'c': [4, 5]}
+    c = cursor(d)
+    # test multiple changes on same element
+    c['b'][0] = 6
+    c['b'][0] = 7
+    d2 = c.build()
+    self.assertEqual(d2, {'a': 1, 'b': (7, 3), 'c': [4, 5]})
+    # test nested changes
+    c['a'] = (100, 200)
+    c['a'][1] = -1
+    d3 = c.build()
+    self.assertEqual(d3, {'a': (100, -1), 'b': (7, 3), 'c': [4, 5]})
+
+  def test_hidden_change(self):
+    # test list
+    l = [1, 2]
+    c = cursor(l)
+    c[0] = 100
+    l[1] = -1
+    l2 = c.build()
+    self.assertEqual(
+        l2, [100, -1]
+    )  # change in l affects l2 (this is expected behavior)
+    self.assertEqual(l, [1, -1])
+
+    # test regular dict
+    d = {'a': 1, 'b': 2}
+    c = cursor(d)
+    c['a'] = 100
+    d['b'] = -1
+    d2 = c.build()
+    self.assertEqual(
+        d2, {'a': 100, 'b': -1}
+    )  # change in d affects d2 (this is expected behavior)
+    self.assertEqual(d, {'a': 1, 'b': -1})
+
+    # test TrainState
+    params = {'a': 1, 'b': 2}
+    state = train_state.TrainState.create(
+        apply_fn=lambda x: x,
+        params=params,
+        tx=optax.adam(1e-3),
+    )
+    c = cursor(state)
+    c.params['a'] = 100
+    params['b'] = -1
+    state2 = c.build()
+    self.assertEqual(
+        state2.params, {'a': 100, 'b': -1}
+    )  # change in state affects state2 (this is expected behavior)
+    self.assertEqual(state.params, {'a': 1, 'b': -1})
+
+  def test_named_tuple_multi_access(self):
+    t = GenericTuple(GenericTuple(0, 1), GenericTuple(2, 3))
+    c = cursor(t)
+    c.x.x = 4
+    c[0].y = 5
+    c.y.x = 6
+    c.y[1] = 7
+    self.assertEqual(
+        c.build(), GenericTuple(GenericTuple(4, 5), GenericTuple(6, 7))
+    )
+
+    c[0][1] = -5
+    self.assertEqual(
+        c.build(), GenericTuple(GenericTuple(4, -5), GenericTuple(6, 7))
+    )
+    c.x[1] = -6
+    self.assertEqual(
+        c.build(), GenericTuple(GenericTuple(4, -6), GenericTuple(6, 7))
+    )
+    c.x.y = -7
+    self.assertEqual(
+        c.build(), GenericTuple(GenericTuple(4, -7), GenericTuple(6, 7))
+    )
+    c[0].y = -8
+    self.assertEqual(
+        c.build(), GenericTuple(GenericTuple(4, -8), GenericTuple(6, 7))
+    )
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/tests/linen/kw_only_dataclasses_test.py
+++ b/tests/linen/kw_only_dataclasses_test.py
@@ -62,7 +62,7 @@ class KwOnlyDataclassesTest(absltest.TestCase):
     v1 = Child(4)
     self.assertDictEqual(dataclasses.asdict(v1), dict(a=2, b=4))
 
-    v2 = Child(4, 5)  # pylint: disable=too-many-function-args
+    v2 = Child(4, a=5)  # pylint: disable=too-many-function-args
     self.assertDictEqual(dataclasses.asdict(v2), dict(a=5, b=4))
 
   def test_subclass_overrides_base(self):

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -824,6 +824,7 @@ class ModuleTest(absltest.TestCase):
         kernel_init = init
         bias_init = zeros
         dot_general = dot_general
+        dot_general_cls = None
     )
     Dense_1 = Dense(
         # attributes
@@ -835,6 +836,7 @@ class ModuleTest(absltest.TestCase):
         kernel_init = init
         bias_init = zeros
         dot_general = dot_general
+        dot_general_cls = None
     )
 )"""
     x = jnp.ones((1, 2))

--- a/tests/linen/linen_module_test.py
+++ b/tests/linen/linen_module_test.py
@@ -2214,6 +2214,18 @@ class ModuleTest(absltest.TestCase):
       # take positional arg. It takes BaseLayer's default kwargs though.
       np.testing.assert_equal(ChildLayer(8)(np.ones(10)), -8 * np.ones(10))
 
+  def test_positional_cannot_be_kw_only(self):
+    class Foo(nn.Module):
+      a: int
+
+    Foo(1)  # ok
+    Foo(a=1)  # ok
+    with self.assertRaisesRegex(
+        TypeError, r'takes 2 positional arguments but 3 were'
+    ):
+      Foo(1, None)
+    Foo(a=1, parent=None)  # type: ignore[call-arg]
+
   def test_intercept_methods(self):
     mod = IdentityModule(parent=None)
     x = jnp.ones([])

--- a/tests/linen/linen_transforms_test.py
+++ b/tests/linen/linen_transforms_test.py
@@ -414,8 +414,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((10, 10))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    _, new_vars = Test(None).apply(init_vars, x, mutable=['counter'])
+    init_vars = Test(parent=None).init(rngs, x)
+    _, new_vars = Test(parent=None).apply(init_vars, x, mutable=['counter'])
     self.assertEqual(
         init_vars['counter']['outer']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
@@ -462,8 +462,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((1, 1))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    _, new_vars = Test(None).apply(init_vars, x, mutable=['counter'])
+    init_vars = Test(parent=None).init(rngs, x)
+    _, new_vars = Test(parent=None).apply(init_vars, x, mutable=['counter'])
     self.assertEqual(
         init_vars['counter']['outer']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
@@ -508,8 +508,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((1, 1))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    _, new_vars = Test(None).apply(init_vars, x, mutable=['counter'])
+    init_vars = Test(parent=None).init(rngs, x)
+    _, new_vars = Test(parent=None).apply(init_vars, x, mutable=['counter'])
     self.assertEqual(
         init_vars['counter']['outer1']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
@@ -563,8 +563,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((1, 1))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    _, new_vars = Test(None).apply(init_vars, x, mutable=['counter'])
+    init_vars = Test(parent=None).init(rngs, x)
+    _, new_vars = Test(parent=None).apply(init_vars, x, mutable=['counter'])
     self.assertEqual(
         init_vars['counter']['outer1']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
@@ -619,8 +619,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((1, 1))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    _, new_vars = Test(None).apply(init_vars, x, mutable=['counter'])
+    init_vars = Test(parent=None).init(rngs, x)
+    _, new_vars = Test(parent=None).apply(init_vars, x, mutable=['counter'])
     self.assertEqual(
         init_vars['counter']['outer']['cntr']['foo'], jnp.array([2], jnp.int32)
     )
@@ -662,8 +662,8 @@ class TransformTest(absltest.TestCase):
 
     x = jnp.ones((3, 1, 2))
     rngs = random.PRNGKey(0)
-    init_vars = Test(None).init(rngs, x)
-    y = Test(None).apply(init_vars, x)
+    init_vars = Test(parent=None).init(rngs, x)
+    y = Test(parent=None).apply(init_vars, x)
     self.assertEqual(
         init_vars['params']['outer']['Dense_0']['kernel'].shape, (3, 2, 5)
     )


### PR DESCRIPTION
Adds sharding annotations to Flax's `Dense`, `DenseGeneral`, `MultiHeadDotProductAttention` and normalization modules. This change makes Flax's modules compatible with [T5X](https://github.com/google-research/t5x).